### PR TITLE
[REVIEW] Bump Python package version to 0.2

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -22,7 +22,7 @@ copyright = "2020, NVIDIA Corporation"
 author = "NVIDIA Corporation"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.0"
+release = "0.2.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/python/setup.py
+++ b/python/setup.py
@@ -32,7 +32,7 @@ extensions = [
 
 setup(
     name="nvtx",
-    version="0.1.0",
+    version="0.2.0",
     description="PyNVTX - Python code annotation library",
     url="https://github.com/NVIDIA/nvtx",
     author="NVIDIA Corporation",


### PR DESCRIPTION
The addition of the `start/end` APIs (PR #7) in Python requires us to bump to 0.2.

cc: @kkraus14 