### PR TITLE
[Python] - Add support for integer type category argument

### DIFF
--- a/python/docs/basic.rst
+++ b/python/docs/basic.rst
@@ -133,9 +133,15 @@ Categories allow grouping of annotations within a domain.
    def func_3():
        time.sleep(1)
 
+
+   @nvtx.annotate(color="red", domain="Domain_2", category=2)
+   def func_4():
+       time.sleep(1)
+
    func_1()
    func_2()
    func_3()
+   func_4()
 
 In the example above, `func_1` and `func_2`
 are grouped under the domain `Domain1`,

--- a/python/nvtx/nvtx.py
+++ b/python/nvtx/nvtx.py
@@ -40,10 +40,10 @@ class annotate(ContextDecorator):
         domain : str, optional
             A string specifying the domain under which the code range is
             scoped. The default domain is named "NVTX".
-        category : str, optional
-            A string specifying the category within the domain under which
-            the code range is scoped. If unspecified, the code range is not
-            associated with a category.
+        category : str, int, optional
+            A string or an integer specifying the category within the domain
+            under which the code range is scoped. If unspecified, the code
+            range is not associated with a category.
 
         Examples
         --------
@@ -64,12 +64,12 @@ class annotate(ContextDecorator):
         """
 
         self.domain = Domain(domain)
-
-        category_id = (
-            self.domain.get_category_id(category)
-            if category is not None
-            else None
-        )
+ 
+        category_id = None
+        if isinstance(category, int):
+            category_id =  category
+        elif isinstance(category, str):
+            category_id = self.domain.get_category_id(category)
         self.attributes = EventAttributes(message, color, category_id)
 
     def __reduce__(self):
@@ -105,17 +105,17 @@ def mark(message=None, color="blue", domain=None, category=None):
     domain : str, optional
         A string specifuing the domain under which the event is scoped.
         The default domain is named "NVTX".
-    category : str, optional
-        A string specifying the category within the domain under which
-        the event is scoped. If unspecified, the event is not associated
-        with a category.
+    category : str, int, optional
+        A string or an integer specifying the category within the domain
+        under which the event is scoped. If unspecified, the event is
+        not associated with a category.
     """
     domain = Domain(domain)
-    category_id = (
-        domain.get_category_id(category)
-        if category is not None
-        else None
-    )
+    category_id = None
+    if isinstance(category, int):
+        category_id =  category
+    elif isinstance(category, str):
+        category_id = domain.get_category_id(category)
     attributes = EventAttributes(message, color, category_id)
     libnvtx_mark(attributes, domain.handle)
 
@@ -134,10 +134,10 @@ def push_range(message=None, color="blue", domain=None, category=None):
     domain : str, optional
         Name of a domain under which the code range is scoped.
         The default domain name is "NVTX".
-    category : str, optional
-        A string specifying the category within the domain under which
-        the event is scoped. If unspecified, the event is not associated
-        with a category.
+    category : str, int, optional
+        A string or an integer specifying the category within the domain
+        under which the code range is scoped. If unspecified, the code range
+        is not associated with a category.
 
     Examples
     --------
@@ -148,11 +148,11 @@ def push_range(message=None, color="blue", domain=None, category=None):
     >>> nvtx.pop_range(domain="my_domain")
     """
     domain = Domain(domain)
-    category_id = (
-        domain.get_category_id(category)
-        if category is not None
-        else None
-    )
+    category_id = None
+    if isinstance(category, int):
+        category_id =  category
+    elif isinstance(category, str):
+        category_id = domain.get_category_id(category)
     libnvtx_push_range(EventAttributes(message, color, category_id), domain.handle)
 
 
@@ -183,10 +183,10 @@ def start_range(message=None, color="blue", domain=None, category=None):
     domain : str, optional
         Name of a domain under which the code range is scoped.
         The default domain name is "NVTX".
-    category : str, optional
-        A string specifying the category within the domain under which
-        the event is scoped. If unspecified, the event is not associated
-        with a category.
+    category : str, int, optional
+        A string or an integer specifying the category within the domain
+        under which the code range is scoped. If unspecified, the code range
+        is not associated with a category.
 
     Returns
     -------
@@ -201,11 +201,11 @@ def start_range(message=None, color="blue", domain=None, category=None):
     >>> nvtx.end_range(range_id, domain="my_domain")
     """
     domain = Domain(domain)
-    category_id = (
-        domain.get_category_id(category)
-        if category is not None
-        else None
-    )
+    category_id = None
+    if isinstance(category, int):
+        category_id =  category
+    elif isinstance(category, str):
+        category_id = domain.get_category_id(category)
     marker_id = libnvtx_start_range(
         EventAttributes(message, color, category_id), domain.handle
     )

--- a/python/nvtx/tests/test_basic.py
+++ b/python/nvtx/tests/test_basic.py
@@ -138,7 +138,9 @@ def test_domain_reuse():
         "y"
         "x",
         "abc",
-        "abc def"
+        "abc def",
+        0,
+        1,
     ]
 )
 def test_categories_basic(message, color, domain, category):
@@ -181,6 +183,7 @@ def test_get_category_id():
     [
         None,
         "abc",
+        1,
     ]
 )
 def test_start_end(message, color, domain, category):
@@ -216,6 +219,7 @@ def test_start_end(message, color, domain, category):
     [
         None,
         "abc",
+        1,
     ]
 )
 def test_push_pop(message, color, domain, category):
@@ -250,6 +254,7 @@ def test_push_pop(message, color, domain, category):
     [
         None,
         "abc",
+        1,
     ]
 )
 def test_mark(message, color, domain, category):


### PR DESCRIPTION
This PR will add support for integer type category argument.

By allowing direct integer type for category argument, hoping that category id bridge between Python script and C/C++ code would be guaranteed.

I suspect choosing string type category argument is done in the name of abstraction and ease of use.
But some people crave for magic numbers, so the road for those poor souls must be paved with good intentions.
