### PR TITLE
Remove dynamic allocation in domain_process_range

### DIFF
--- a/cpp/include/nvtx3/nvtx3.hpp
+++ b/cpp/include/nvtx3/nvtx3.hpp
@@ -2065,27 +2065,34 @@ class domain_process_range {
    * @brief Destroy the `domain_process_range` ending the range.
    *
    */
-  ~domain_process_range()
+  ~domain_process_range() noexcept
   {
-    if (handle_) { end_range(*handle_); }
+    if (handle_.get_value() != range_handle::null_handle) { end_range(handle_); }
   }
 
   /**
    * @brief Move constructor allows taking ownership of the NVTX range from
    * another `domain_process_range`.
    *
-   * @param other
+   * @param other The range to take ownership of
    */
-  domain_process_range(domain_process_range&& other) = default;
+  constexpr domain_process_range(domain_process_range&& other) noexcept : handle_{other.handle_}
+  {
+    other.handle_ = range_handle::null_handle;
+  }
 
   /**
    * @brief Move assignment operator allows taking ownership of an NVTX range
    * from another `domain_process_range`.
    *
-   * @param other
-   * @return domain_process_range&
+   * @param other The range to take ownership of
    */
-  domain_process_range& operator=(domain_process_range&& other) = default;
+  constexpr domain_process_range& operator=(domain_process_range&& other) noexcept
+  {
+    handle_       = other.handle_;
+    other.handle_ = range_handle::null_handle;
+    return *this;
+  }
 
   /// Copy construction is not allowed to prevent multiple objects from owning
   /// the same range handle
@@ -2096,8 +2103,8 @@ class domain_process_range {
   domain_process_range& operator=(domain_process_range const&) = delete;
 
  private:
-  std::unique_ptr<range_handle> handle_;  ///< Range handle used to correlate
-                                          ///< the start/end of the range
+  range_handle handle_;  ///< Range handle used to correlate
+                         ///< the start/end of the range
 };
 
 /**

--- a/cpp/include/nvtx3/nvtx3.hpp
+++ b/cpp/include/nvtx3/nvtx3.hpp
@@ -2143,10 +2143,7 @@ class domain_process_range {
    * @brief Destroy the `domain_process_range` ending the range.
    *
    */
-  ~domain_process_range() noexcept
-  {
-    if (handle_.get_value() != range_handle::null_handle) { end_range(handle_); }
-  }
+  ~domain_process_range() noexcept = default;
 
   /**
    * @brief Move constructor allows taking ownership of the NVTX range from
@@ -2154,10 +2151,7 @@ class domain_process_range {
    *
    * @param other The range to take ownership of
    */
-  constexpr domain_process_range(domain_process_range&& other) noexcept : handle_{other.handle_}
-  {
-    other.handle_ = range_handle::null_handle;
-  }
+  constexpr domain_process_range(domain_process_range&& other) noexcept = default;
 
   /**
    * @brief Move assignment operator allows taking ownership of an NVTX range
@@ -2165,12 +2159,7 @@ class domain_process_range {
    *
    * @param other The range to take ownership of
    */
-  constexpr domain_process_range& operator=(domain_process_range&& other) noexcept
-  {
-    handle_       = other.handle_;
-    other.handle_ = range_handle::null_handle;
-    return *this;
-  }
+  constexpr domain_process_range& operator=(domain_process_range&& other) noexcept = default;
 
   /// Copy construction is not allowed to prevent multiple objects from owning
   /// the same range handle
@@ -2181,8 +2170,12 @@ class domain_process_range {
   domain_process_range& operator=(domain_process_range const&) = delete;
 
  private:
-  range_handle handle_;  ///< Range handle used to correlate
-                         ///< the start/end of the range
+  struct end_range_handle {
+    using pointer = range_handle;  /// Override the pointer type of the unique_ptr
+    void operator()(range_handle h) const noexcept { end_range(h); }
+  };
+  std::unique_ptr<range_handle, end_range_handle> handle_;  ///< Range handle used to correlate
+                                                            ///< the start/end of the range
 };
 
 /**

--- a/cpp/include/nvtx3/nvtx3.hpp
+++ b/cpp/include/nvtx3/nvtx3.hpp
@@ -1892,8 +1892,6 @@ struct range_handle {
   /// Type used for the handle's value
   using value_type = nvtxRangeId_t;
 
-  /// Sentinel value for a null handle that corresponds to no range
-  static constexpr value_type null_handle = nvtxRangeId_t{0};
 
   /**
    * @brief Construct a `range_handle` from the given id.
@@ -1918,7 +1916,7 @@ struct range_handle {
    * \endcode
    *
    */
-  constexpr explicit operator bool() const noexcept { return get_value() != null_handle; };
+  constexpr explicit operator bool() const noexcept { return get_value() != null_range_id; };
 
   /**
    * @brief Implicit conversion from `nullptr` constructs a null handle.
@@ -1936,7 +1934,10 @@ struct range_handle {
   constexpr value_type get_value() const noexcept { return _range_id; }
 
  private:
-  value_type _range_id{null_handle};  ///< The underlying NVTX range id
+  /// Sentinel value for a null handle that corresponds to no range
+  static constexpr value_type null_range_id = nvtxRangeId_t{0};
+
+  value_type _range_id{null_range_id};  ///< The underlying NVTX range id
 };
 
 /**

--- a/cpp/include/nvtx3/nvtx3.hpp
+++ b/cpp/include/nvtx3/nvtx3.hpp
@@ -2031,20 +2031,48 @@ template <typename D = domain::global>
 class domain_process_range {
  public:
   /**
-   * @brief Construct a new domain process range object
+   * @brief Construct a new domain process range object with the specified event attributes
    *
-   * @param attr
+   * Example:
+   * \code{cpp}
+   * nvtx3::event_attributes attr{"msg", nvtx3::rgb{127,255,0}};
+   * nvtx3::domain_process_range<> range{attr}; // Creates a range with message contents
+   *                                            // "msg" and green color
+   * \endcode
+   *
+   * @param[in] attr `event_attributes` that describes the desired attributes
+   * of the range.
    */
   explicit domain_process_range(event_attributes const& attr) noexcept
-    : handle_{new range_handle{start_range<D>(attr)}}
+    : handle_{start_range<D>(attr)}
   {
   }
 
   /**
-   * @brief Construct a new domain process range object
+   * @brief Constructs a `domain_process_range` from the constructor arguments
+   * of an `event_attributes`.
    *
-   * @param first
-   * @param args
+   * Forwards the arguments `first, args...` to construct an
+   * `event_attributes` object. The `event_attributes` object is then
+   * associated with the `domain_process_range`.
+   *
+   * For more detail, see `event_attributes` documentation.
+   *
+   * Example:
+   * ```
+   * // Creates a range with message "message" and green color
+   * nvtx3::domain_process_range<> r{"message", nvtx3::rgb{127,255,0}};
+   * ```
+   *
+   * @note To prevent making needless copies of `event_attributes` objects,
+   * this constructor is disabled when the first argument is an
+   * `event_attributes` object, instead preferring the explicit
+   * `domain_thread_range(event_attributes const&)` constructor.
+   *
+   * @param[in] first First argument to forward to the `event_attributes`
+   * constructor.
+   * @param[in] args Variadic parameter pack of additional arguments to
+   * forward.
    */
   template <typename First,
             typename... Args,
@@ -2056,7 +2084,8 @@ class domain_process_range {
   }
 
   /**
-   * @brief Construct a new domain process range object
+   * @brief Default constructor creates a `domain_process_range` with no
+   * message, color, payload, nor category.
    *
    */
   constexpr domain_process_range() noexcept : domain_process_range{event_attributes{}} {}

--- a/cpp/include/nvtx3/nvtx3.hpp
+++ b/cpp/include/nvtx3/nvtx3.hpp
@@ -2155,7 +2155,7 @@ class domain_process_range {
    *
    * @param other The range to take ownership of
    */
-  constexpr domain_process_range(domain_process_range&& other) noexcept = default;
+  domain_process_range(domain_process_range&& other) noexcept = default;
 
   /**
    * @brief Move assignment operator allows taking ownership of an NVTX range
@@ -2163,7 +2163,7 @@ class domain_process_range {
    *
    * @param other The range to take ownership of
    */
-  constexpr domain_process_range& operator=(domain_process_range&& other) noexcept = default;
+  domain_process_range& operator=(domain_process_range&& other) noexcept = default;
 
   /// Copy construction is not allowed to prevent multiple objects from owning
   /// the same range handle

--- a/cpp/include/nvtx3/nvtx3.hpp
+++ b/cpp/include/nvtx3/nvtx3.hpp
@@ -1949,7 +1949,7 @@ struct range_handle {
  * @param lhs The first range_handle to compare
  * @param rhs The second range_handle to compare
  */
-constexpr bool operator==(range_handle lhs, range_handle rhs)
+constexpr bool operator==(range_handle lhs, range_handle rhs) noexcept
 {
   return lhs.get_value() == rhs.get_value();
 }
@@ -1960,7 +1960,7 @@ constexpr bool operator==(range_handle lhs, range_handle rhs)
  * @param lhs The first range_handle to compare
  * @param rhs The second range_handle to compare
  */
-constexpr bool operator!=(range_handle lhs, range_handle rhs) { return !(lhs == rhs); }
+constexpr bool operator!=(range_handle lhs, range_handle rhs) noexcept { return !(lhs == rhs); }
 
 /**
  * @brief Manually begin an NVTX range.

--- a/cpp/include/nvtx3/nvtx3.hpp
+++ b/cpp/include/nvtx3/nvtx3.hpp
@@ -1902,6 +1902,9 @@ struct range_handle {
   /**
    * @brief Constructs a null range handle.
    *
+   * A null range_handle corresponds to no range. Calling `end_range` on a null handle is undefined
+   * behavior.
+   *
    */
   constexpr range_handle() noexcept = default;
 

--- a/cpp/include/nvtx3/nvtx3.hpp
+++ b/cpp/include/nvtx3/nvtx3.hpp
@@ -1889,6 +1889,9 @@ struct range_handle {
   /// Type used for the handle's value
   using value_type = nvtxRangeId_t;
 
+  /// Sentinel value for a null handle that corresponds to no range
+  static constexpr value_type null_handle = nvtxRangeId_t{0};
+
   /**
    * @brief Construct a `range_handle` from the given id.
    *


### PR DESCRIPTION
Closes https://github.com/NVIDIA/NVTX/issues/29

Updated `range_handle` to satisfy the requirements of [NullablePointer](https://en.cppreference.com/w/cpp/named_req/NullablePointer):
- Added operator==/operator!=
- Added conversion to bool
- Added a "null" state for nvtxRangeId_t == 0 (since 0 is never a valid range value)
- Add conversion from nullptr to allow comparison with nullptr

Updated the unique_ptr with a custom deleter that overrides the `pointer` type to avoid the dynamic allocation.