### PR TITLE
doc fix code format start_range

### DIFF
--- a/python/docs/basic.rst
+++ b/python/docs/basic.rst
@@ -46,6 +46,7 @@ and returns a handle. The handle is passed to the ``end_range()`` function,
 which is called at the end of the code range.
 
 ::
+
    rng = nvtx.start_range(message="my_message", color="blue")
    # ... do something ... #
    nvtx.end_range(rng)


### PR DESCRIPTION
Fixing typo errror in code format in start_range and end_range.