### PR TITLE
Add empty cibw job to default branch

### DIFF
--- a/.github/workflows/cibw.yml
+++ b/.github/workflows/cibw.yml
@@ -1,0 +1,17 @@
+# this job is an empty no-op because we need a cibw.yml in the default branch
+# to be able to use the manual workflow_dispatch
+#   https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+#
+# the real version of the job is in the dev branch
+
+name: Build wheels for NVTX
+
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: no-op
+        run: echo "Hello World!"


### PR DESCRIPTION
This adds a placeholder job, cibw.yml, to the default "release-v3" branch of NVTX.

This allows the NVTX maintainers to kick off manual jobs to make wheel releases in the future.

The real useful copy of cibw.yml will be introduced to the "dev" branch (which does the actual cibuildwheel steps to produce x86_64 and aarch64 wheels and publish them to PyPI), but it's still a requirement for manual workflows that the same-named file **must** be present in the default branch.