### PR TITLE
Add cibuildwheel manual GH Actions workflow

### DIFF
--- a/.github/workflows/cibw.yml
+++ b/.github/workflows/cibw.yml
@@ -1,0 +1,123 @@
+name: Build wheels for NVTX
+
+on:
+  workflow_dispatch:
+    inputs:
+      repo:
+        description: 'NVTX repo to use'
+        required: true
+        default: 'NVIDIA/NVTX'
+        type: string
+      branchOrTag:
+        description: 'Branch or tag to checkout'
+        required: true
+        default: 'dev'
+        type: string
+      prNumber:
+        description: 'PR number (overrides branch/tag if > 0)'
+        required: false
+        type: integer
+        default: 0
+      publishToPyPI:
+        description: 'Publish to PyPI'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    name: Build wheels on ${{ matrix.os }} ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+        - os: 'ubuntu-latest'
+          cibw_archs_linux: "x86_64"
+          docker_py_container: "python"
+          name: 'ubuntu-x86_64'
+        - os: 'ubuntu-latest'
+          cibw_archs_linux: "aarch64"
+          docker_py_container: "arm64v8/python"
+          name: 'ubuntu-qemu-aarch64'
+          qemu: true
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # unshallow fetch for setuptools-scm
+        repository: ${{ inputs.repo }}
+        ref: ${{ inputs.branchOrTag }}
+
+    - name: Check out PR code if prNumber is specified
+      if: inputs.prNumber > 0
+      uses: dawidd6/action-checkout-pr@v1
+      with:
+        pr: ${{ inputs.prNumber }}
+        repo: ${{ inputs.repo }}
+
+    - name: Set up QEMU
+      if: matrix.qemu
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: arm64
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.4.0
+      env:
+        CIBW_SKIP: "*musllinux*"
+        CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
+        CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+        CIBW_TEST_COMMAND: "pytest {package}/nvtx/tests"
+        CIBW_TEST_REQUIRES: "pytest"
+        CIBW_REPAIR_WHEEL_COMMAND_LINUX: 'auditwheel repair -w {dest_dir} {wheel}'
+        CIBW_ENVIRONMENT: "C_INCLUDE_PATH=$(pwd)/c/include"
+      with:
+        output-dir: dist
+        package-dir: python
+
+    - name: Run docker smoke tests for all python versions
+      run: |
+        for pyver in 3.7 3.8 3.9 3.10; do
+          docker run --rm -v $(pwd)/dist:/wheels ${{ matrix.docker_py_container}}:$pyver-bullseye sh -c "python3 -m pip install --verbose --find-links=file:///wheels --no-index nvtx && python3 -c 'import nvtx; print(nvtx.annotate())';"
+        done
+
+    - name: Upload distributions
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist
+        name: nvtx-wheels
+
+  publish:
+    needs: build
+    name: Publish release to Pypi
+    runs-on: ubuntu-latest
+    if: success() && ${{ inputs.publishToPyPI }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # unshallow fetch for setuptools-scm
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    - name: Download assets
+      uses: actions/download-artifact@v1.0.0
+      with:
+        name: nvtx-wheels
+        path: python/dist
+
+    - name: Build sdist and publish package to PyPI
+      working-directory: python
+      run: |
+        python -m pip install toml twine
+        BUILD_REQUIREMENTS=`python -c 'import toml; print(" ".join(toml.load("pyproject.toml")["build-system"]["requires"]))'`
+        python -m pip install ${BUILD_REQUIREMENTS}
+        python setup.py sdist
+        twine upload dist/*
+      env:
+        TWINE_USERNAME: ${{ secrets.pypi_username }}
+        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+        C_INCLUDE_PATH: "../c/include"

--- a/.github/workflows/cibw.yml
+++ b/.github/workflows/cibw.yml
@@ -79,7 +79,11 @@ jobs:
     - name: Run docker smoke tests for all python versions
       run: |
         for pyver in 3.7 3.8 3.9 3.10; do
-          docker run --rm -v $(pwd)/dist:/wheels ${{ matrix.docker_py_container}}:$pyver-bullseye sh -c "python3 -m pip install --verbose --find-links=file:///wheels --no-index nvtx && python3 -c 'import nvtx; print(nvtx.annotate())';"
+          docker run --rm \
+            -v $(pwd)/dist:/wheels \
+            ${{ matrix.docker_py_container}}:$pyver-bullseye \
+            sh -c \
+            "python3 -m pip install --verbose --find-links=file:///wheels --no-index nvtx && python3 -m pip check && python3 -c 'import nvtx; print(nvtx.annotate())';" ;\
         done
 
     - name: Upload distributions


### PR DESCRIPTION
This commit adds a GitHub Actions manual workflow to improve the Python build and release process. The workflow can be kicked off from the Actions UI.

This replaces the current manual wheel building + publishing script (defined in https://github.com/NVIDIA/NVTX/blob/dev/python/tools/build-wheels.sh) with cibuildwheel (https://github.com/pypa/cibuildwheel), a powerful CI tool for wheel building and publishing.

It keeps all of the same behavior (manylinux2014, Python matrix across 3.7/8/9/10, auditwheel repair command, twine publish to PyPI), and adds a few wins:
- Adds aarch64 wheels, built via qemu emulation
- Adds a smoke/import test by installing the built wheels in a clean Docker container before publishing to PyPI

Note that a no-op variant of the same `cibw.yml` file must also be committed to the default branch, to be able to use this version of the file from the dev branch - the PR for that is here: https://github.com/NVIDIA/NVTX/pull/55 

Lastly, PyPI credentials have not been figured out yet, but the majority of the build works and has been tested extensively in my own fork (example: https://github.com/sevagh/NVTX/runs/6986254607?check_suite_focus=true)
