### PR TITLE
Update image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Normally, this program waits for 6 seconds, and does nothing else.
 
 Launch it from [NVIDIA Nsight Systems](https://developer.nvidia.com/nsight-systems), and you'll see this execution on a timeline:
 
-![alt text](https://raw.githubusercontent.com/jrhemstad/nvtx_wrappers/master/docs/example_range.png "Example NVTX Ranges in Nsight Systems")
+![alt text](https://raw.githubusercontent.com/NVIDIA/NVTX/release-v3/docs/images/example_range.png "Example NVTX Ranges in Nsight Systems")
 
 The NVTX row shows the function's name "some_function" in the top-level range and the "loop range" message in the nested ranges.  The loop iterations each last for the expected one second.
 

--- a/c/README.md
+++ b/c/README.md
@@ -37,7 +37,7 @@ Normally, this program waits for 6 seconds, and does nothing else.
 
 Launch it from **NVIDIA Nsight Systems**, and you'll see this execution on a timeline:
 
-![alt text](https://raw.githubusercontent.com/jrhemstad/nvtx_wrappers/master/docs/example_range.png "Example NVTX Ranges in Nsight Systems")
+![alt text](https://raw.githubusercontent.com/NVIDIA/NVTX/release-v3/docs/images/example_range.png "Example NVTX Ranges in Nsight Systems")
 
 The NVTX row shows the function's name "some_function" in the top-level range and the "loop range" message in the nested ranges.  The loop iterations each last for the expected one second.
 

--- a/c/include/nvtx3/nvtx3.hpp
+++ b/c/include/nvtx3/nvtx3.hpp
@@ -126,7 +126,7 @@
  * Systems:
  *
  * \image html
- * https://raw.githubusercontent.com/jrhemstad/nvtx_wrappers/master/docs/example_range.png
+ * https://raw.githubusercontent.com/NVIDIA/NVTX/release-v3/docs/images/example_range.png
  *
  * Alternatively, use the \ref MACROS like `NVTX3_FUNC_RANGE()` to add
  * ranges to your code that automatically use the name of the enclosing function


### PR DESCRIPTION
The example range image still referenced the copy in my personal repo.

Updated the link to refer to the image in this repo. 