### PR TITLE
NVTX3 requires CMake 3.19+ as we set properties on INTERFACE targets

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.19)
 
 # This file is typically used by calling add_subdirectory on this directory or add
 # this directory as an external package.  In this case, the NVTX library targets

--- a/c/nvtxImportedTargets.cmake
+++ b/c/nvtxImportedTargets.cmake
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #=============================================================================
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.19)
 
 set(NVTX3_VERSION 3.1.0)
 


### PR DESCRIPTION
The CMake 3.19 relaxation on `INTERFACE` targets to have sources aslo removed all restrictions around which properties an INTERFACE target can have ( https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5078 ). NVTX3 is adding the version property to INTERFACE targets and so requires 3.19+