### PR TITLE
fix include statements for cross compilation

### DIFF
--- a/c/include/nvtx3/nvtxDetail/nvtxImpl.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxImpl.h
@@ -14,7 +14,7 @@
 
 #if defined(_WIN32) 
 
-#include <Windows.h>
+#include <windows.h>
 
 #else
 #include <unistd.h>
@@ -25,6 +25,10 @@
 
 #if defined(__linux__) || defined(__CYGWIN__)
 #include <sched.h>
+#endif
+
+#if defined(__linux__)
+#include <linux/limits.h>
 #endif
 
 #include <limits.h>


### PR DESCRIPTION
This fixes two errors I found when using NVTX in a cross compilation environmemt (https://github.com/JuliaPackaging/Yggdrasil/pull/5863):

1. `windows.h` should be lower-case
2. `PATH_MAX` is in `linux/limits.h`
