### PR TITLE
remove hidden pragmas

### DIFF
--- a/c/include/nvtx3/nvtxDetail/nvtxImpl.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxImpl.h
@@ -69,10 +69,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#ifdef __GNUC__
-#pragma GCC visibility push(hidden)
-#endif
-
 /* ---- Forward declare all functions referenced in globals ---- */
 
 NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_VERSIONED_IDENTIFIER(nvtxInitOnce)(void);
@@ -428,10 +424,6 @@ NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxEtiSet
 /* ---- Define implementations of initialization functions ---- */
 
 #include "nvtxInit.h"
-
-#ifdef __GNUC__
-#pragma GCC visibility pop
-#endif
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
These prevent building of a shared library (as described in https://github.com/NVIDIA/NVTX#other-languages), and appear to be redundant in any case.

See https://forums.developer.nvidia.com/t/building-nvtx-as-a-dynamic-library/235031?u=simonbyrne1