### PR TITLE
Update setup.py to include headers from CUDA_HOME

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -22,7 +22,7 @@ except Exception:
 
 include_dirs = [os.path.dirname(sysconfig.get_path("include")),]
 if os.getenv("CUDA_HOME"):
-  include_dirs.insert(0, os.path.join(os.environ["CUDA_HOME"], "include"))
+    include_dirs.insert(0, os.path.join(os.environ["CUDA_HOME"], "include"))
 library_dirs = [get_python_lib()]
 
 if nvtx_include_dir := os.getenv("NVTX_PREFIX"):

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,6 +21,8 @@ except Exception:
     nthreads = 0
 
 include_dirs = [os.path.dirname(sysconfig.get_path("include")),]
+if os.getenv("CUDA_HOME"):
+  include_dirs.insert(0, os.path.join(os.environ["CUDA_HOME"], "include"))
 library_dirs = [get_python_lib()]
 
 if nvtx_include_dir := os.getenv("NVTX_PREFIX"):


### PR DESCRIPTION
NVTX needs headers `nvtx3/nvToolsExt.h` to build. These headers are from the cuda installation.

On systems where cuda is not installed at a default prefix, `CUDA_HOME` is an environment variable that many software (e.g. pytorch) uses to identify where cuda is installed.  https://www.google.com/search?q=CUDA_HOME

This PR adds support so that NVTX can find cuda from the `CUDA_HOME` variable.