### PR TITLE
Create sdists in build workflow.

### DIFF
--- a/.github/workflows/cibw.yml
+++ b/.github/workflows/cibw.yml
@@ -31,10 +31,26 @@ jobs:
           name: 'ubuntu-qemu-aarch64'
           qemu: true
     steps:
-    - uses: actions/checkout@v3
+    - name: Check out repository
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # unshallow fetch for setuptools-scm
         ref: ${{ inputs.branchOrTag }}
+
+    - name: Set up Python
+      # Only build sdists on x86_64
+      if: matrix.cibw_archs_linux == 'x86_64'
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+
+    - name: Build source distribution
+      # Only build sdists on x86_64
+      if: matrix.cibw_archs_linux == 'x86_64'
+      run: |
+        python3 -m pip install build --user
+        python3 -m build --sdist --outdir dist/ ./python/
+
     - name: Set up QEMU
       if: matrix.qemu
       uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
This PR adds source distribution (sdist) artifacts to the cibuildwheel workflows. The sdist is built only on x86_64 (only one configuration is needed). It appears in the artifacts of that build. See https://github.com/bdice/NVTX/pull/1 and https://github.com/bdice/NVTX/actions/runs/5967235268?pr=1 for examples of this, tested on a PR to my fork of the repo. I have verified that the `.tar.gz` artifact is a part of that artifact zip, alongside wheels for various Python minor versions.

cc: @shwina