### PR TITLE
Python: fix nullcontext usage when disabled

### DIFF
--- a/python/nvtx/nvtx.py
+++ b/python/nvtx/nvtx.py
@@ -280,7 +280,7 @@ if not enabled():
 
     class annotate(contextlib.nullcontext):
         def __init__(self, *args, **kwargs):
-            pass
+            super().__init__()
 
         def __call__(self, func):
             return func


### PR DESCRIPTION
Hello,

I have encountered a problem with NVTX Python when `NVTX_DISABLE` is set.
Here is how to reproduce it:

```bash
python3.11 -m venv .venv
source .venv/bin/activate
pip install --upgrade nvtx
# Successfully installed nvtx-0.2.5
```

With the following short test file:

```py
import nvtx

@nvtx.annotate('test1')
def test1():
    print('test1')

test1()

with nvtx.annotate('test2'):
    print('test2')
```

The result is:

```bash
$ NVTX_DISABLE=1 python ./test_nvtx.py
test1
Traceback (most recent call last):
  File "/home/merlin/Desktop/nvtx-test/./test_nvtx.py", line 10, in <module>
    with nvtx.annotate('test2'):
  File "/usr/lib/python3.11/contextlib.py", line 755, in __enter__
    return self.enter_result
           ^^^^^^^^^^^^^^^^^
AttributeError: 'annotate' object has no attribute 'enter_result'
```

With the proposed fix, the test script runs without issues.