### PR TITLE
Fix Windows build when WIN32_LEAN_AND_MEAN is defined by always including stdlib.h (nvbug 200683304)

### DIFF
--- a/c/include/nvtx3/nvtxDetail/nvtxImpl.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxImpl.h
@@ -12,6 +12,8 @@
 
 /* ---- Include required platform headers ---- */
 
+#include <stdlib.h>
+
 #if defined(_WIN32) 
 
 #include <Windows.h>
@@ -30,7 +32,6 @@
 #include <limits.h>
 #include <dlfcn.h>
 #include <fcntl.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -39,7 +40,6 @@
 #include <string.h>
 #include <sys/types.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include <wchar.h>
 
 #endif


### PR DESCRIPTION
This fixes the bug where this code:

```cpp
#define WIN32_LEAN_AND_MEAN
#include <nvtx3/nvToolsExt.h>

int main() {}
```

outputs

```output
1>...\include\nvtx3\nvtxDetail\nvtxInit.h(164,32): error C3861: '_wgetenv': identifier not found
```

Normally, `#include <Windows.h>` in nvtxImpl.h would include `<stdlib.h>` — unless `WIN32_LEAN_AND_MEAN` is defined. In that case, nothing defines `_wgetenv`. This pull request should fix that by moving `#include <stdlib.h>` out of the Linux-only preprocessor branch.

Thanks!