### PR TITLE
Python: fix automatic annotation based on function name

### DIFF
--- a/python/nvtx/nvtx.py
+++ b/python/nvtx/nvtx.py
@@ -104,7 +104,7 @@ class annotate:
         return False
 
     def __call__(self, func):
-        if not self.attributes.message:
+        if not self.attributes.message.string:
             self.attributes.message = RegisteredString(
                 self.domain.handle, func.__name__
             )

--- a/python/nvtx/tests/test_basic.py
+++ b/python/nvtx/tests/test_basic.py
@@ -259,3 +259,13 @@ def test_push_pop(message, color, domain, category):
 )
 def test_mark(message, color, domain, category):
     nvtx.mark(message, color, domain, category)
+
+
+def test_annotation_gets_name_from_func():
+    # GH #86: test that annotate() with no arguments
+    # uses the name of the function as the message
+    ann = nvtx.annotate()
+    def foo():
+        pass
+    ann(foo)
+    assert ann.attributes.message.string == "foo"


### PR DESCRIPTION
Fixes #85.

Note that I have only tested this locally on my limited use-case.