### PR TITLE
Python: Fixed wheel building on windows by adding path to included header files.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -20,7 +20,8 @@ try:
 except Exception:
     nthreads = 0
 
-include_dirs = [os.path.dirname(sysconfig.get_path("include")),]
+include_dirs = [os.path.dirname(sysconfig.get_path("include")),
+                os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "c", "include")]
 if os.getenv("CUDA_HOME"):
     include_dirs.insert(0, os.path.join(os.environ["CUDA_HOME"], "include"))
 library_dirs = [get_python_lib()]


### PR DESCRIPTION
Fixes #80 and other build issues. No need to set C_INCLUDE_PATH=../c/include/ since we automatically add it to the paths (cross platform).

This allows it to be used like a typical python dependency as long as the CUDA include paths are already setup (e.g. if someone already compiled a CUDA example).

