### PR TITLE
Add missing brackets around object construction

### DIFF
--- a/c/include/nvtx3/nvtx3.hpp
+++ b/c/include/nvtx3/nvtx3.hpp
@@ -1927,9 +1927,9 @@ class event_attributes {
         0,                              // color value
         NVTX_PAYLOAD_UNKNOWN,           // payload type
         0,                              // reserved 4B
-        0,                              // payload value (union)
+        {0},                            // payload value (union)
         NVTX_MESSAGE_UNKNOWN,           // message type
-        0                               // message value (union)
+        {0}                             // message value (union)
       }
   {
   }


### PR DESCRIPTION
Fixes:
```
nvtx3/nvtx3.hpp:1931:9: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
        0,                              // payload value (union)
        ^
        {}
nvtx3/nvtx3.hpp:1933:9: error: suggest braces around initialization of subobject [-Werror,-Wmissing-braces]
        0                               // message value (union)
        ^
        {}
```
after this the code should be able to compile with `-Wmissing-braces`.