### PR TITLE
Python: add support for int and float payloads

### DIFF
--- a/python/nvtx/_lib/lib.pxd
+++ b/python/nvtx/_lib/lib.pxd
@@ -109,6 +109,7 @@ cdef class EventAttributes:
     cdef object _message
     cdef object _color
     cdef uint32_t _category
+    cdef object _payload
     cdef nvtxStringHandle_t string_handle
     cdef nvtxEventAttributes_t c_obj
 

--- a/python/nvtx/_lib/lib.pyx
+++ b/python/nvtx/_lib/lib.pyx
@@ -20,7 +20,7 @@ def initialize():
 
 cdef class EventAttributes:
 
-    def __init__(self, object message=None, color=None, category=None):
+    def __init__(self, object message=None, color=None, category=None, payload=None):
         self.c_obj = nvtxEventAttributes_t(0)
         self.c_obj.version = NVTX_VERSION
         self.c_obj.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE
@@ -30,7 +30,7 @@ cdef class EventAttributes:
         self.message = message
         self.color = color
         self.category = category
-
+        self.payload = payload
 
     @property
     def message(self):
@@ -59,6 +59,24 @@ cdef class EventAttributes:
         if value is not None:
             self._category = value
             self.c_obj.category = value
+
+    @property
+    def payload(self):
+        return self._payload
+
+    @payload.setter
+    def payload(self, value):
+        if value is not None:
+            self._payload = value
+
+            if isinstance(self._payload, int):
+                self.c_obj.payload.llValue = self._payload
+                self.c_obj.payloadType = NVTX_PAYLOAD_TYPE_INT64
+            elif isinstance(self._payload, float):
+                self.c_obj.payload.dValue = self._payload
+                self.c_obj.payloadType = NVTX_PAYLOAD_TYPE_DOUBLE
+            else:
+                raise RuntimeError('Payload must be int or float') 
 
 
 cdef class DomainHandle:

--- a/python/nvtx/nvtx.py
+++ b/python/nvtx/nvtx.py
@@ -20,7 +20,6 @@ from nvtx._lib import (
     end_range as libnvtx_end_range,
 )
 
-
 _ENABLED = not os.getenv("NVTX_DISABLE", False)
 
 
@@ -29,7 +28,7 @@ class annotate:
     Annotate code ranges using a context manager or a decorator.
     """
 
-    def __init__(self, message=None, color=None, domain=None, category=None):
+    def __init__(self, message=None, color=None, domain=None, category=None, payload=None):
         """
         Annotate a function or a code range.
 
@@ -55,6 +54,8 @@ class annotate:
             A string or an integer specifying the category within the domain
             under which the code range is scoped. If unspecified, the code
             range is not associated with a category.
+        payload : int or float, optional
+            A numeric value to be associated with this event
 
         Examples
         --------
@@ -82,7 +83,7 @@ class annotate:
             category_id = category
         elif isinstance(category, str):
             category_id = self.domain.get_category_id(category)
-        self.attributes = EventAttributes(message, color, category_id)
+        self.attributes = EventAttributes(message, color, category_id, payload)
 
     def __reduce__(self):
         return (
@@ -119,7 +120,7 @@ class annotate:
         return inner
 
 
-def mark(message=None, color="blue", domain=None, category=None):
+def mark(message=None, color="blue", domain=None, category=None, payload=None):
     """
     Mark an instantaneous event.
 
@@ -140,6 +141,8 @@ def mark(message=None, color="blue", domain=None, category=None):
         A string or an integer specifying the category within the domain
         under which the event is scoped. If unspecified, the event is
         not associated with a category.
+    payload : int or float, optional
+            A numeric value to be associated with this event
     """
     domain = Domain(domain)
     message = RegisteredString(domain.handle, message)
@@ -149,11 +152,11 @@ def mark(message=None, color="blue", domain=None, category=None):
         category_id = category
     elif isinstance(category, str):
         category_id = domain.get_category_id(category)
-    attributes = EventAttributes(message, color, category_id)
+    attributes = EventAttributes(message, color, category_id, payload)
     libnvtx_mark(attributes, domain.handle)
 
 
-def push_range(message=None, color="blue", domain=None, category=None):
+def push_range(message=None, color="blue", domain=None, category=None, payload=None):
     """
     Mark the beginning of a code range.
 
@@ -175,6 +178,8 @@ def push_range(message=None, color="blue", domain=None, category=None):
         A string or an integer specifying the category within the domain
         under which the code range is scoped. If unspecified, the code range
         is not associated with a category.
+    payload : int or float, optional
+            A numeric value to be associated with this event
 
     Examples
     --------
@@ -192,7 +197,8 @@ def push_range(message=None, color="blue", domain=None, category=None):
         category_id = category
     elif isinstance(category, str):
         category_id = domain.get_category_id(category)
-    libnvtx_push_range(EventAttributes(message, color, category_id), domain.handle)
+    libnvtx_push_range(EventAttributes(message, color, category_id, payload),
+                       domain.handle)
 
 
 def pop_range(domain=None):
@@ -208,7 +214,7 @@ def pop_range(domain=None):
     libnvtx_pop_range(Domain(domain).handle)
 
 
-def start_range(message=None, color="blue", domain=None, category=None):
+def start_range(message=None, color="blue", domain=None, category=None, payload=None):
     """
     Mark the beginning of a code range.
 
@@ -230,6 +236,8 @@ def start_range(message=None, color="blue", domain=None, category=None):
         A string or an integer specifying the category within the domain
         under which the code range is scoped. If unspecified, the code range
         is not associated with a category.
+    payload : int or float, optional
+            A numeric value to be associated with this event
 
     Returns
     -------
@@ -252,8 +260,7 @@ def start_range(message=None, color="blue", domain=None, category=None):
     elif isinstance(category, str):
         category_id = domain.get_category_id(category)
     marker_id = libnvtx_start_range(
-        EventAttributes(message, color, category_id), domain.handle
-    )
+        EventAttributes(message, color, category_id, payload), domain.handle)
     return marker_id
 
 
@@ -287,16 +294,16 @@ if not enabled():
 
     # Could use a decorator here but overheads are significant enough
     # not to. See https://github.com/NVIDIA/NVTX/pull/24 for discussion.
-    def mark(message=None, color=None, domain=None, category=None):
+    def mark(message=None, color=None, domain=None, category=None, payload=None):
         pass
 
-    def push_range(message=None, color=None, domain=None, category=None):
+    def push_range(message=None, color=None, domain=None, category=None, payload=None):
         pass
 
     def pop_range(domain=None):
         pass
 
-    def start_range(message=None, color=None, domain=None, category=None):
+    def start_range(message=None, color=None, domain=None, category=None, payload=None):
         pass
 
     def end_range(range_id):

--- a/python/nvtx/tests/test_basic.py
+++ b/python/nvtx/tests/test_basic.py
@@ -40,8 +40,16 @@ import nvtx
         "abc def"
     ]
 )
-def test_annotate_context_manager(message, color, domain):
-    with nvtx.annotate(message=message, color=color, domain=domain):
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        1,
+        1.0
+    ]
+)
+def test_annotate_context_manager(message, color, domain, payload):
+    with nvtx.annotate(message=message, color=color, domain=domain, payload=payload):
         pass
 
 
@@ -74,8 +82,16 @@ def test_annotate_context_manager(message, color, domain):
         "abc def"
     ]
 )
-def test_annotate_decorator(message, color, domain):
-    @nvtx.annotate(message=message, color=color, domain=domain)
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        1,
+        1.0
+    ]
+)
+def test_annotate_decorator(message, color, domain, payload):
+    @nvtx.annotate(message=message, color=color, domain=domain, payload=payload)
     def foo():
         pass
 
@@ -186,8 +202,16 @@ def test_get_category_id():
         1,
     ]
 )
-def test_start_end(message, color, domain, category):
-    rng = nvtx.start_range(message, color, domain, category)
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        1,
+        1.0
+    ]
+)
+def test_start_end(message, color, domain, category, payload):
+    rng = nvtx.start_range(message, color, domain, category, payload)
     nvtx.end_range(rng)
 
 
@@ -222,8 +246,16 @@ def test_start_end(message, color, domain, category):
         1,
     ]
 )
-def test_push_pop(message, color, domain, category):
-    nvtx.push_range(message, color, domain, category)
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        1,
+        1.0
+    ]
+)
+def test_push_pop(message, color, domain, category, payload):
+    nvtx.push_range(message, color, domain, category, payload)
     nvtx.pop_range()
     
 
@@ -257,8 +289,16 @@ def test_push_pop(message, color, domain, category):
         1,
     ]
 )
-def test_mark(message, color, domain, category):
-    nvtx.mark(message, color, domain, category)
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        1,
+        1.0
+    ]
+)
+def test_mark(message, color, domain, category, payload):
+    nvtx.mark(message, color, domain, category, payload)
 
 
 def test_annotation_gets_name_from_func():


### PR DESCRIPTION
As referenced in #89

In addition to the basic unit tests, I've confirmed that nsys and Nsight systems see the payloads properly via a simple script:
```python
import nvtx
import time

for i in range(0, 100):
    with nvtx.annotate('loop', payload=i):
        nvtx.mark('intvalue', payload=i)
        nvtx.mark('floatvalue', payload=float(i))
        time.sleep(0.01)
```
![image](https://github.com/NVIDIA/NVTX/assets/1388377/95a8a07e-a5ae-4b5d-ab5f-59d027f51ce2)
![image](https://github.com/NVIDIA/NVTX/assets/1388377/95d0c965-bc07-4804-b036-8e1fa5191b8a)
![image](https://github.com/NVIDIA/NVTX/assets/1388377/4eccf122-fa88-4dad-8f4b-cd98d01b4c3e)
