### PR TITLE
Fix clang warning on missing braces

### DIFF
--- a/c/include/nvtx3/nvtx3.hpp
+++ b/c/include/nvtx3/nvtx3.hpp
@@ -1936,9 +1936,9 @@ class event_attributes {
         0,                              // color value
         NVTX_PAYLOAD_UNKNOWN,           // payload type
         0,                              // reserved 4B
-        0,                              // payload value (union)
+        {0},                            // payload value (union)
         NVTX_MESSAGE_UNKNOWN,           // message type
-        0                               // message value (union)
+        {0}                             // message value (union)
       }
   {
   }


### PR DESCRIPTION
When clang++ is used as host compiler after nvcc, it emits a warning when compiling with `-Wmissing-braces`, because nvcc emits parentheses around the initializer for a union instead of braces.

Warning observed with clang++-17 and nvcc 12.4 when `nvtx3.hpp` is used inside [CCCL](https://github.com/NVIDIA/cccl).