### PR TITLE
Make NVTX CMake relocatable.

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -36,47 +36,47 @@ cmake_minimum_required(VERSION 3.10)
 # Project declaration needs to be before the configuration
 project(nvtx3 VERSION 3.1.1)
 
-# Add installation rules
-include(GNUInstallDirs)
-include(CMakePackageConfigHelpers)
+# Determine if this is the root project
+set(NVTX3_IS_ROOT_PROJECT "${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+option(NVTX3_INSTALL "Install NVTX3" ${NVTX3_IS_ROOT_PROJECT})
 
 set(NVTX3_TARGETS_NOT_USING_IMPORTED ON)
 include(nvtxImportedTargets.cmake)
+set_target_properties(nvtx3-c PROPERTIES EXPORT_PROPERTIES VERSION)
 
+if(NVTX3_INSTALL)
+    # Add installation rules
+    include(GNUInstallDirs)
+    include(CMakePackageConfigHelpers)
 
-set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/nvtx3")
+    # Configure the config file
+    configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/nvtx3-config.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake"
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3"
+    )
 
-# Configure the config file
-configure_package_config_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/nvtx3-config.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3"
-    PATH_VARS INCLUDE_INSTALL_DIR
-)
+    # Generate version file
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config-version.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
+    )
 
-# Generate version file
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config-version.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
+    # Install headers
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-# Install headers
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-        FILES_MATCHING PATTERN "*.h"
-                       PATTERN "*.hpp")
+    # Install the config files
+    install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config-version.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3"
+    )
 
-# Install the config files
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config-version.cmake"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3"
-)
-
-# Install the targets
-install(EXPORT nvtx3-targets
-    FILE nvtx3-targets.cmake
-    NAMESPACE nvtx3::
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3")
-
+    # Install the targets
+    install(EXPORT nvtx3-targets
+        FILE nvtx3-targets.cmake
+        NAMESPACE nvtx3::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3")
+endif()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -48,6 +48,7 @@ if(NVTX3_INSTALL)
     include(CMakePackageConfigHelpers)
 
     # Configure the config file
+    message(STATUS "Writing config file to ${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake")
     configure_package_config_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/nvtx3-config.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake"

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -33,5 +33,50 @@ cmake_minimum_required(VERSION 3.10)
 # IMPORTED option, which only defines the targets within the scope of the library.
 # This allows the same target name to be used for different NVTX versions.
 
+# Project declaration needs to be before the configuration
+project(nvtx3 VERSION 3.1.1)
+
+# Add installation rules
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
 set(NVTX3_TARGETS_NOT_USING_IMPORTED ON)
 include(nvtxImportedTargets.cmake)
+
+
+set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/nvtx3")
+
+# Configure the config file
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/nvtx3-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3"
+    PATH_VARS INCLUDE_INSTALL_DIR
+)
+
+# Generate version file
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+# Install headers
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+        FILES_MATCHING PATTERN "*.h"
+                       PATTERN "*.hpp")
+
+# Install the config files
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3"
+)
+
+# Install the targets
+install(EXPORT nvtx3-targets
+    FILE nvtx3-targets.cmake
+    NAMESPACE nvtx3::
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3")
+

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -36,12 +36,7 @@ cmake_minimum_required(VERSION 3.10)
 # Project declaration needs to be before the configuration
 project(nvtx3 VERSION 3.1.1)
 
-# Determine if this is the root project
-set(NVTX3_IS_ROOT_PROJECT FALSE)
-if("${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
-    set(NVTX3_IS_ROOT_PROJECT TRUE)
-endif()
-option(NVTX3_INSTALL "Install NVTX3" ${NVTX3_IS_ROOT_PROJECT})
+option(NVTX3_INSTALL "Install NVTX3" ON)
 
 set(NVTX3_TARGETS_NOT_USING_IMPORTED ON)
 include(nvtxImportedTargets.cmake)

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -79,4 +79,7 @@ if(NVTX3_INSTALL)
         FILE nvtx3-targets.cmake
         NAMESPACE nvtx3::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3")
+    export(EXPORT nvtx3-targets
+        FILE ntx3-targets.cmake
+        NAMESPACE nvtx3::)
 endif()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -80,6 +80,6 @@ if(NVTX3_INSTALL)
         NAMESPACE nvtx3::
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/nvtx3")
     export(EXPORT nvtx3-targets
-        FILE ntx3-targets.cmake
+        FILE nvtx3-targets.cmake
         NAMESPACE nvtx3::)
 endif()

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -48,7 +48,6 @@ if(NVTX3_INSTALL)
     include(CMakePackageConfigHelpers)
 
     # Configure the config file
-    message(STATUS "Writing config file to ${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake")
     configure_package_config_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/nvtx3-config.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/nvtx3-config.cmake"

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -37,7 +37,10 @@ cmake_minimum_required(VERSION 3.10)
 project(nvtx3 VERSION 3.1.1)
 
 # Determine if this is the root project
-set(NVTX3_IS_ROOT_PROJECT "${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+set(NVTX3_IS_ROOT_PROJECT FALSE)
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}")
+    set(NVTX3_IS_ROOT_PROJECT TRUE)
+endif()
 option(NVTX3_INSTALL "Install NVTX3" ${NVTX3_IS_ROOT_PROJECT})
 
 set(NVTX3_TARGETS_NOT_USING_IMPORTED ON)
@@ -75,6 +78,7 @@ if(NVTX3_INSTALL)
     )
 
     # Install the targets
+    install(TARGETS nvtx3-c nvtx3-cpp EXPORT nvtx3-targets)
     install(EXPORT nvtx3-targets
         FILE nvtx3-targets.cmake
         NAMESPACE nvtx3::

--- a/c/examples/CMakeLists.txt
+++ b/c/examples/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.10)
+project(nvtx3_example)
+
+# Specify C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find NVTX3 package
+find_package(nvtx3 REQUIRED)
+
+# Show where the package is installed
+message(STATUS "NVTX3 package is installed in: ${nvtx3_DIR}")
+
+# Show the include directory of target nvtx3-cpp
+get_target_property(nvtx3_include_dir nvtx3::nvtx3-c INTERFACE_INCLUDE_DIRECTORIES)
+message(STATUS "NVTX3 include directory: ${nvtx3_include_dir}")
+
+# Create an example executable
+add_executable(example main.cpp)
+target_link_libraries(example PRIVATE nvtx3::nvtx3-cpp)

--- a/c/examples/CMakeLists.txt
+++ b/c/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.19)
 project(nvtx3_example)
 
 # Specify C++ standard

--- a/c/examples/main.cpp
+++ b/c/examples/main.cpp
@@ -1,0 +1,6 @@
+#include <nvtx3/nvtx3.hpp>
+
+int main() {
+    nvtx3::mark("Hello NVTX!");
+    return 0;
+}

--- a/c/nvtx3-config.cmake.in
+++ b/c/nvtx3-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Include the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/nvtx3-targets.cmake")
+

--- a/c/nvtxImportedTargets.cmake
+++ b/c/nvtxImportedTargets.cmake
@@ -55,18 +55,23 @@ else()
     #-------------------------------------------------------
     # Define "nvtx3-c" library for the NVTX v3 C API
     add_library(nvtx3-c INTERFACE ${OPTIONALLY_IMPORTED})
+    add_library(nvtx3::nvtx3-c ALIAS nvtx3-c)
     set_target_properties(nvtx3-c PROPERTIES VERSION ${NVTX3_VERSION})
     target_include_directories(nvtx3-c INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-        "$<INSTALL_INTERFACE:include>")
+        "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
     target_link_libraries(nvtx3-c INTERFACE ${CMAKE_DL_LIBS})
 
     #-------------------------------------------------------
     # Define "nvtx3-cpp" library for the NVTX v3 C++ API
     # Separate target allows attaching independent compiler requirements if needed
     add_library(nvtx3-cpp INTERFACE ${OPTIONALLY_IMPORTED})
+    add_library(nvtx3::nvtx3-cpp ALIAS nvtx3-cpp)
     set_target_properties(nvtx3-cpp PROPERTIES VERSION ${NVTX3_VERSION})
     target_link_libraries(nvtx3-cpp INTERFACE nvtx3-c)
+
+    # Install the targets
+    install(TARGETS nvtx3-c nvtx3-cpp EXPORT nvtx3-targets)
 endif()
 
 unset(OPTIONALLY_IMPORTED)

--- a/c/nvtxImportedTargets.cmake
+++ b/c/nvtxImportedTargets.cmake
@@ -69,9 +69,6 @@ else()
     add_library(nvtx3::nvtx3-cpp ALIAS nvtx3-cpp)
     set_target_properties(nvtx3-cpp PROPERTIES VERSION ${NVTX3_VERSION})
     target_link_libraries(nvtx3-cpp INTERFACE nvtx3-c)
-
-    # Install the targets
-    install(TARGETS nvtx3-c nvtx3-cpp EXPORT nvtx3-targets)
 endif()
 
 unset(OPTIONALLY_IMPORTED)


### PR DESCRIPTION
This resolves #113.

I added a config and targets file, using the existing logic in `CMakeLists.txt` and `nvtxImportedTargets.cmake`. I tried to modify these files in a way that wouldn't break existing uses of the CMake code (which apparently only works via `add_subdirectory`).

I tested these changes with:

```bash
mkdir -p /tmp/nvtx-install
mkdir -p c/build

pushd c/build
rm -rf * && rm -rf /tmp/nvtx-install/* && cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/nvtx-install && cmake --build . && cmake --install .
popd

mkdir -p c/examples/build

pushd c/examples/build
rm -rf * && cmake .. -DCMAKE_PREFIX_PATH=/tmp/nvtx-install && cmake --build .
popd
```

I think the NVTX relocatable install in `/tmp/nvtx-install` looks like it should work, based on my knowledge of how rapids-cmake works (https://github.com/rapidsai/rapids-cmake/blob/branch-25.04/rapids-cmake/cpm/nvtx3.cmake). The example code builds and runs with the appropriate include directories.

To move this PR forward, this may need some or all of the following:
- Better CMake test code in CI, perhaps this can be done in a separate PR prior to merging this PR. The current code in `c/examples` should probably be in a directory of CMake tests somewhere.
- Some kind of documentation changes? The NVTX docs appear to live in several places.
- Review from two of the RAPIDS CMake folks: @robertmaynard, @vyasr, @KylefromNVIDIA
- Review from NVTX maintainers
