### PR TITLE
Remove usages of `module` as an identifier.

### DIFF
--- a/c/include/nvtx3/nvtxDetail/nvtxExtImplCounters_v1.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxExtImplCounters_v1.h
@@ -77,7 +77,7 @@ NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_EXT_COUNTERS_VERSIONED_ID(nvtxExtCounter
         NVTX_NULLPTR /* function slots */
     };
 
-    nvtxExtModuleInfo_t module = {
+    nvtxExtModuleInfo_t module_info = {
         NVTX_VERSION, sizeof(nvtxExtModuleInfo_t),
         NVTX_EXT_COUNTERS_MODULEID, NVTX_EXT_COUNTERS_COMPATID,
         1, NVTX_NULLPTR, /* number of segments, segments */
@@ -86,11 +86,11 @@ NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_EXT_COUNTERS_VERSIONED_ID(nvtxExtCounter
     };
 
     segment.functionSlots = fnSlots;
-    module.segments = &segment;
+    module_info.segments = &segment;
 
     NVTX_INFO( "%s\n", __FUNCTION__  );
 
-    NVTX_VERSIONED_IDENTIFIER(nvtxExtInitOnce)(&module,
+    NVTX_VERSIONED_IDENTIFIER(nvtxExtInitOnce)(&module_info,
         NVTX_EXT_COUNTERS_VERSIONED_ID(nvtxExtCountersSlots));
 }
 

--- a/c/include/nvtx3/nvtxDetail/nvtxExtImplMem_v1.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxExtImplMem_v1.h
@@ -77,7 +77,7 @@ NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_EXT_MEM_VERSIONED_ID(nvtxExtMemInitOnce)
         NVTX_NULLPTR /* function slots */
     };
 
-    nvtxExtModuleInfo_t module = {
+    nvtxExtModuleInfo_t module_info = {
         NVTX_VERSION, sizeof(nvtxExtModuleInfo_t),
         NVTX_EXT_MODULEID_MEM, NVTX_EXT_COMPATID_MEM,
         1, NVTX_NULLPTR, /* number of segments, segments */
@@ -86,11 +86,11 @@ NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_EXT_MEM_VERSIONED_ID(nvtxExtMemInitOnce)
     };
 
     segment.functionSlots = fnSlots;
-    module.segments = &segment;
+    module_info.segments = &segment;
 
     NVTX_INFO( "%s\n", __FUNCTION__  );
 
-    NVTX_VERSIONED_IDENTIFIER(nvtxExtInitOnce)(&module,
+    NVTX_VERSIONED_IDENTIFIER(nvtxExtInitOnce)(&module_info,
         NVTX_EXT_MEM_VERSIONED_ID(nvtxExtMemSlots));
 }
 

--- a/c/include/nvtx3/nvtxDetail/nvtxExtImplPayload_v1.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxExtImplPayload_v1.h
@@ -85,7 +85,7 @@ NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadI
         NVTX_NULLPTR /* function slots */
     };
 
-    nvtxExtModuleInfo_t module = {
+    nvtxExtModuleInfo_t module_info = {
         NVTX_VERSION, sizeof(nvtxExtModuleInfo_t),
         NVTX_EXT_PAYLOAD_MODULEID, NVTX_EXT_PAYLOAD_COMPATID,
         1, NVTX_NULLPTR, /* number of segments, segments */
@@ -95,11 +95,11 @@ NVTX_LINKONCE_DEFINE_FUNCTION void NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadI
     };
 
     segment.functionSlots = fnSlots;
-    module.segments = &segment;
+    module_info.segments = &segment;
 
     NVTX_INFO( "%s\n", __FUNCTION__  );
 
-    NVTX_VERSIONED_IDENTIFIER(nvtxExtInitOnce)(&module,
+    NVTX_VERSIONED_IDENTIFIER(nvtxExtInitOnce)(&module_info,
         NVTX_EXT_PAYLOAD_VERSIONED_ID(nvtxExtPayloadSlots));
 }
 
@@ -227,4 +227,3 @@ NVTX_EXT_PAYLOAD_IMPL_FN_V1(void, nvtxEventBatchSubmit, (nvtxDomainHandle_t doma
 #endif /* __cplusplus */
 
 #endif /* NVTX_EXT_IMPL_PAYLOAD_V1 */
-

--- a/c/include/nvtx3/nvtxDetail/nvtxImpl.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxImpl.h
@@ -96,7 +96,7 @@ extern "C" {
 
 NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_VERSIONED_IDENTIFIER(nvtxInitOnce)(void);
 NVTX_LINKONCE_FWDDECL_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxEtiGetModuleFunctionTable)(
-    NvtxCallbackModule module,
+    NvtxCallbackModule callback_module,
     NvtxFunctionTable* out_table,
     unsigned int* out_size);
 NVTX_LINKONCE_FWDDECL_FUNCTION void NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxEtiSetInjectionNvtxVersion)(
@@ -383,14 +383,14 @@ NVTX_LINKONCE_DEFINE_GLOBAL nvtxGlobals_t NVTX_VERSIONED_IDENTIFIER(nvtxGlobals)
 /* ---- Define implementations of export table functions ---- */
 
 NVTX_LINKONCE_DEFINE_FUNCTION int NVTX_API NVTX_VERSIONED_IDENTIFIER(nvtxEtiGetModuleFunctionTable)(
-    NvtxCallbackModule module,
+    NvtxCallbackModule callback_module,
     NvtxFunctionTable* out_table,
     unsigned int* out_size)
 {
     unsigned int bytes = 0;
     NvtxFunctionTable table = NVTX_NULLPTR;
 
-    switch (module)
+    switch (callback_module)
     {
     case NVTX_CB_MODULE_CORE:
         table = NVTX_VERSIONED_IDENTIFIER(nvtxGlobals).functionTable_CORE;

--- a/c/include/nvtx3/nvtxDetail/nvtxTypes.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxTypes.h
@@ -292,7 +292,7 @@ typedef struct NvtxExportTableCallbacks
 
     /* returns an array of pointer to function pointers*/
     int (NVTX_API *GetModuleFunctionTable)(
-        NvtxCallbackModule module,
+        NvtxCallbackModule callback_module,
         NvtxFunctionTable* out_table,
         unsigned int* out_size);
 } NvtxExportTableCallbacks;
@@ -316,10 +316,3 @@ typedef struct NvtxExportTableVersionInfo
     void (NVTX_API *SetInjectionNvtxVersion)(
         uint32_t version);
 } NvtxExportTableVersionInfo;
-
-
-
-
-
-
-

--- a/tools/sample-injection/Source/NvtxSampleInjection.cpp
+++ b/tools/sample-injection/Source/NvtxSampleInjection.cpp
@@ -72,7 +72,7 @@ struct TearDownDetector
 //
 // [1] https://github.com/NVIDIA/NVTX/blob/v3.1.1/c/include/nvtx3/nvtxDetail/nvtxTypes.h#L277
 // [2] https://github.com/NVIDIA/NVTX/blob/v3.1.1/c/include/nvtx3/nvtxDetail/nvtxTypes.h#L138
-NvtxFunctionTable GetFunctionTable(NvtxGetExportTableFunc_t getExportTable, NvtxCallbackModule module) {
+NvtxFunctionTable GetFunctionTable(NvtxGetExportTableFunc_t getExportTable, NvtxCallbackModule callbackModule) {
     auto callbacks = reinterpret_cast<const NvtxExportTableCallbacks*>(getExportTable(NVTX_ETID_CALLBACKS));
     if (!callbacks) {
         fprintf(stderr, "[NVTX] Could not get NVTX_ETID_CALLBACKS.\n");
@@ -81,8 +81,8 @@ NvtxFunctionTable GetFunctionTable(NvtxGetExportTableFunc_t getExportTable, Nvtx
 
     NvtxFunctionTable table = nullptr;
     unsigned int tableSize = 0;
-    if (!callbacks->GetModuleFunctionTable(module, &table, &tableSize)) {
-        fprintf(stderr, "[NVTX] Could not get function table of module %d.\n", module);
+    if (!callbacks->GetModuleFunctionTable(callbackModule, &table, &tableSize)) {
+        fprintf(stderr, "[NVTX] Could not get function table of module %d.\n", callbackModule);
         return nullptr;
     }
 


### PR DESCRIPTION
`module` is now a C++ keyword, and this is causing issues with nvc++ c++20 builds.

Closes #120.