### PR TITLE
Python fix: Make @nvtx.annotate close the NVTX range when an exception is thrown

### DIFF
--- a/python/src/nvtx/nvtx.py
+++ b/python/src/nvtx/nvtx.py
@@ -119,8 +119,11 @@ class annotate:
         @wraps(func)
         def inner(*args, **kwargs):
             libnvtx_push_range(self.attributes, self.domain.handle)
-            result = func(*args, **kwargs)
-            libnvtx_pop_range(self.domain.handle)
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                # Always pop the range, even if an exception is raised
+                libnvtx_pop_range(self.domain.handle)
             return result
 
         return inner

--- a/python/tests/test_nvtx_annotate_pushes_and_pops.py
+++ b/python/tests/test_nvtx_annotate_pushes_and_pops.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://nvidia.github.io/NVTX/LICENSE.txt for license information.
+
+import unittest.mock
+
+import pytest
+
+import nvtx
+
+
+def test_annotate_ctx_manager_pops():
+    """
+    Test that the NVTX range is properly popped when the context manager is exited normally.
+    """
+    # Create a mock domain that behaves like a real domain
+    mock_domain = unittest.mock.MagicMock()
+    mock_domain.handle = unittest.mock.MagicMock()
+    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
+    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
+
+    # Mock get_domain to return our mock domain instead of dummy_domain
+    with unittest.mock.patch(
+        "nvtx.nvtx.get_domain", return_value=mock_domain
+    ), unittest.mock.patch(
+        "nvtx.nvtx.libnvtx_push_range"
+    ) as mock_push, unittest.mock.patch(
+        "nvtx.nvtx.libnvtx_pop_range"
+    ) as mock_pop:
+
+        with nvtx.annotate():
+            pass
+
+        mock_push.assert_called_once()
+        mock_pop.assert_called_once()
+
+
+def test_annotate_ctx_manager_pops_with_exception():
+    """
+    Test that the NVTX range is properly popped when the context manager throws an exception.
+    """
+    # Create a mock domain that behaves like a real domain
+    mock_domain = unittest.mock.MagicMock()
+    mock_domain.handle = unittest.mock.MagicMock()
+    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
+    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
+
+    # Mock get_domain to return our mock domain instead of dummy_domain
+    with unittest.mock.patch(
+        "nvtx.nvtx.get_domain", return_value=mock_domain
+    ), unittest.mock.patch(
+        "nvtx.nvtx.libnvtx_push_range"
+    ) as mock_push, unittest.mock.patch(
+        "nvtx.nvtx.libnvtx_pop_range"
+    ) as mock_pop:
+
+        with pytest.raises(Exception):
+            with nvtx.annotate():
+                raise Exception("test")
+
+        mock_push.assert_called_once()
+
+        # Make sure that pop_range was called even though an exception was raised
+        # inside the context manager for nvtx.annotate
+        mock_pop.assert_called_once()
+
+
+def test_annotate_decorator_pushes_and_pops():
+    """
+    Test that the NVTX range is properly popped when a decorated function exits normally.
+    """
+    # Create a mock domain that behaves like a real domain
+    mock_domain = unittest.mock.MagicMock()
+    mock_domain.handle = unittest.mock.MagicMock()
+    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
+    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
+
+    # Mock get_domain to return our mock domain instead of dummy_domain
+    with unittest.mock.patch(
+        "nvtx.nvtx.get_domain", return_value=mock_domain
+    ), unittest.mock.patch(
+        "nvtx.nvtx.libnvtx_push_range"
+    ) as mock_push, unittest.mock.patch(
+        "nvtx.nvtx.libnvtx_pop_range"
+    ) as mock_pop:
+
+        @nvtx.annotate(message="foo", color="blue", domain="test")
+        def foo():
+            pass
+
+        foo()
+
+        mock_push.assert_called_once()
+        mock_pop.assert_called_once()
+
+
+def test_annotate_decorator_pushes_and_pops_with_exception():
+    """
+    Test that the NVTX range is properly popped when a decorated function raises an exception.
+    """
+    # Create a mock domain that behaves like a real domain
+    mock_domain = unittest.mock.MagicMock()
+    mock_domain.handle = unittest.mock.MagicMock()
+    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
+    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
+
+    # Mock get_domain to return our mock domain instead of dummy_domain
+    with unittest.mock.patch(
+        "nvtx.nvtx.get_domain", return_value=mock_domain
+    ), unittest.mock.patch(
+        "nvtx.nvtx.libnvtx_push_range"
+    ) as mock_push, unittest.mock.patch(
+        "nvtx.nvtx.libnvtx_pop_range"
+    ) as mock_pop:
+
+        @nvtx.annotate(message="foo", color="blue", domain="test")
+        def foo():
+            raise Exception("test")
+
+        with pytest.raises(Exception):
+            foo()
+
+        mock_push.assert_called_once()
+
+        # Make sure that pop_range was called even though an exception was raised
+        # inside the function decorated with nvtx.annotate
+        mock_pop.assert_called_once()

--- a/python/tests/test_nvtx_annotate_pushes_and_pops.py
+++ b/python/tests/test_nvtx_annotate_pushes_and_pops.py
@@ -23,119 +23,89 @@ import pytest
 import nvtx
 
 
-def test_annotate_ctx_manager_pops():
+@pytest.fixture
+def mock_domain():
+    mock_domain = unittest.mock.MagicMock()
+    mock_domain.handle = unittest.mock.MagicMock()
+    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
+    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
+    with unittest.mock.patch(
+        "nvtx.nvtx.get_domain", return_value=mock_domain
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_push():
+    with unittest.mock.patch("nvtx.nvtx.libnvtx_push_range") as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_pop():
+    with unittest.mock.patch("nvtx.nvtx.libnvtx_pop_range") as mock:
+        yield mock
+
+
+def test_annotate_ctx_manager_pops(mock_domain, mock_push, mock_pop):
     """
     Test that the NVTX range is properly popped when the context manager is exited normally.
     """
-    # Create a mock domain that behaves like a real domain
-    mock_domain = unittest.mock.MagicMock()
-    mock_domain.handle = unittest.mock.MagicMock()
-    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
-    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
+    with nvtx.annotate():
+        pass
 
-    # Mock get_domain to return our mock domain instead of dummy_domain
-    with unittest.mock.patch(
-        "nvtx.nvtx.get_domain", return_value=mock_domain
-    ), unittest.mock.patch(
-        "nvtx.nvtx.libnvtx_push_range"
-    ) as mock_push, unittest.mock.patch(
-        "nvtx.nvtx.libnvtx_pop_range"
-    ) as mock_pop:
-
-        with nvtx.annotate():
-            pass
-
-        mock_push.assert_called_once()
-        mock_pop.assert_called_once()
+    mock_push.assert_called_once()
+    mock_pop.assert_called_once()
 
 
-def test_annotate_ctx_manager_pops_with_exception():
+def test_annotate_ctx_manager_pops_with_exception(
+    mock_domain, mock_push, mock_pop
+):
     """
     Test that the NVTX range is properly popped when the context manager throws an exception.
     """
-    # Create a mock domain that behaves like a real domain
-    mock_domain = unittest.mock.MagicMock()
-    mock_domain.handle = unittest.mock.MagicMock()
-    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
-    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
+    with pytest.raises(Exception):
+        with nvtx.annotate():
+            raise Exception("test")
 
-    # Mock get_domain to return our mock domain instead of dummy_domain
-    with unittest.mock.patch(
-        "nvtx.nvtx.get_domain", return_value=mock_domain
-    ), unittest.mock.patch(
-        "nvtx.nvtx.libnvtx_push_range"
-    ) as mock_push, unittest.mock.patch(
-        "nvtx.nvtx.libnvtx_pop_range"
-    ) as mock_pop:
+    mock_push.assert_called_once()
 
-        with pytest.raises(Exception):
-            with nvtx.annotate():
-                raise Exception("test")
-
-        mock_push.assert_called_once()
-
-        # Make sure that pop_range was called even though an exception was raised
-        # inside the context manager for nvtx.annotate
-        mock_pop.assert_called_once()
+    # Make sure that pop_range was called even though an exception was raised
+    # inside the context manager for nvtx.annotate
+    mock_pop.assert_called_once()
 
 
-def test_annotate_decorator_pushes_and_pops():
+def test_annotate_decorator_pushes_and_pops(mock_domain, mock_push, mock_pop):
     """
     Test that the NVTX range is properly popped when a decorated function exits normally.
     """
-    # Create a mock domain that behaves like a real domain
-    mock_domain = unittest.mock.MagicMock()
-    mock_domain.handle = unittest.mock.MagicMock()
-    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
-    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
 
-    # Mock get_domain to return our mock domain instead of dummy_domain
-    with unittest.mock.patch(
-        "nvtx.nvtx.get_domain", return_value=mock_domain
-    ), unittest.mock.patch(
-        "nvtx.nvtx.libnvtx_push_range"
-    ) as mock_push, unittest.mock.patch(
-        "nvtx.nvtx.libnvtx_pop_range"
-    ) as mock_pop:
+    @nvtx.annotate(message="foo", color="blue", domain="test")
+    def foo():
+        pass
 
-        @nvtx.annotate(message="foo", color="blue", domain="test")
-        def foo():
-            pass
+    foo()
 
-        foo()
-
-        mock_push.assert_called_once()
-        mock_pop.assert_called_once()
+    mock_push.assert_called_once()
+    mock_pop.assert_called_once()
 
 
-def test_annotate_decorator_pushes_and_pops_with_exception():
+def test_annotate_decorator_pushes_and_pops_with_exception(
+    mock_domain, mock_push, mock_pop
+):
     """
     Test that the NVTX range is properly popped when a decorated function raises an exception.
     """
-    # Create a mock domain that behaves like a real domain
-    mock_domain = unittest.mock.MagicMock()
-    mock_domain.handle = unittest.mock.MagicMock()
-    mock_domain.get_event_attributes.return_value = unittest.mock.MagicMock()
-    mock_domain.get_registered_string.return_value = unittest.mock.MagicMock()
 
-    # Mock get_domain to return our mock domain instead of dummy_domain
-    with unittest.mock.patch(
-        "nvtx.nvtx.get_domain", return_value=mock_domain
-    ), unittest.mock.patch(
-        "nvtx.nvtx.libnvtx_push_range"
-    ) as mock_push, unittest.mock.patch(
-        "nvtx.nvtx.libnvtx_pop_range"
-    ) as mock_pop:
+    @nvtx.annotate(message="foo", color="blue", domain="test")
+    def foo():
+        raise Exception("test")
 
-        @nvtx.annotate(message="foo", color="blue", domain="test")
-        def foo():
-            raise Exception("test")
+    with pytest.raises(Exception):
+        foo()
 
-        with pytest.raises(Exception):
-            foo()
+    mock_push.assert_called_once()
 
-        mock_push.assert_called_once()
-
-        # Make sure that pop_range was called even though an exception was raised
-        # inside the function decorated with nvtx.annotate
-        mock_pop.assert_called_once()
+    # Make sure that pop_range was called even though an exception was raised
+    # inside the function decorated with nvtx.annotate
+    mock_pop.assert_called_once()


### PR DESCRIPTION
I was using nvtx.annotate as a Python decorator like this:

```
@nvtx.annotate("foo")
def some_function():
      # code throws exception some time.
```

I found that if some_function threw an exception, the NVTX range "foo" was never closed, so its duration would seem to extend all the way to end of the trace, even though the some_function is no longer executing.

By contrast, using nvtx.annotate as a context manager works as expected, which is that even when an exception is thrown, the NVTX range is closed as soon as the block of code is exited:

```
with nvtx.annotate("foo"):
   # code throws exception
```

I made a change to ensure the that first case behaves like the second, so any NVTX range opened by an annotated function will be closed at the time that function exits by throwing an exception.

I also added tests to specify the expected behavior.