### PR TITLE
char8_t: support glibc <2.36 

### DIFF
--- a/c/include/nvtx3/nvtxDetail/nvtxExtPayloadTypeInfo.h
+++ b/c/include/nvtx3/nvtxDetail/nvtxExtPayloadTypeInfo.h
@@ -43,6 +43,11 @@ typedef void* nvtx_payload_pointer_type;
 
 /* `char8_t` is available as of C++20 or C23 */
 #if ((defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || (defined(__cplusplus) && __cplusplus >= 201811L)) && !defined(__APPLE__)
+/* Fallback for systems where glibc < 2.36 does not define char8_t
+ * in uchar.h even when the compiler supports C23 (e.g. RHEL 9). */
+#ifndef __cpp_char8_t
+typedef unsigned char char8_t;
+#endif
 #define NVTX_HAVE_CHAR8 1
 #else
 #define NVTX_HAVE_CHAR8 0


### PR DESCRIPTION
This PR addresses a compilation issue with the nvtx 3.3.0 package, with the python bindings enabled (as a dep of py-torch), when built with GCC 15.2.0 and glibc 2.34 on a RHEL9 system.  IIUC, glibc 2.36 or newer is needed to use char8_t from the c20 standard (https://lists.gnu.org/archive/html/info-gnu/2022-08/msg00000.html).

I was installing via spack and have a PR for a patch here: https://github.com/spack/spack-packages/pull/4531

Note, I have not directly built/tested these changes outside of spack.  Please let me know if there is some testing I can/should do on my end.

On our system, the following code reproduces the bug:

```
$ cat foo.c 
#include <stdio.h> 
//---- uncomment the following block to compile ----
//#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
//#ifndef __cpp_char8_t
//typedef unsigned char char8_t;
//#endif
//#endif
int main() { char8_t a; printf("%ld\n", (long)__STDC_VERSION__); return 0; }

$ gcc --version
gcc (Spack GCC) 15.2.0
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

##  show glibc version
$ ldd --version   
ldd (GNU libc) 2.34
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.

$ gcc foo.c -o foo
foo.c: In function 'main':
foo.c:9:14: error: unknown type name 'char8_t'; did you mean 'char'?
    9 | int main() { char8_t a; printf("%ld\n", (long)__STDC_VERSION__); return 0; }
      |              ^~~~~~~
      |              char
```
