### PR TITLE
Rust: Add `nvtx-sys` `tools` feature exposing the tools/injection ABI

### DIFF
--- a/rust/crates/nvtx-sys/Cargo.toml
+++ b/rust/crates/nvtx-sys/Cargo.toml
@@ -26,6 +26,9 @@ std = ["widestring/std"]
 alloc = ["widestring/alloc"]
 cuda = []
 cuda_runtime = []
+# Expose the NVTX tools/injection ABI (`nvtxDetail/nvtxTypes.h`) for tools
+# implementing injection libraries.
+tools = []
 
 [lints]
 workspace = true

--- a/rust/crates/nvtx-sys/build.rs
+++ b/rust/crates/nvtx-sys/build.rs
@@ -58,10 +58,27 @@ fn main() {
         // allow cuda types
         .allowlist_type("CU.*")
         .allowlist_type("cuda.*")
-        // disallow any fntypes
-        .blocklist_type(".*fntype.*")
         // disallow impl-specific
         .blocklist_type("__.*");
+
+    if cfg!(feature = "tools") {
+        builder = builder
+            // expose the callback-subscription types (export tables, callback
+            // modules, and callback ids)
+            .allowlist_type("Nvtx.*")
+            // expose the dependency-free fake types referenced by the
+            // fakeimpl fntypes (required because allowlisting is not recursive)
+            .allowlist_type("nvtx_.*")
+            // expose the injection result codes
+            .allowlist_var("NVTX_SUCCESS")
+            .allowlist_var("NVTX_FAIL")
+            .allowlist_var("NVTX_ERR_.*");
+        // the function-table slot signatures (`*_impl_fntype` and
+        // `*_fakeimpl_fntype`) are covered by the "nvtx[^_].*" allowlist above
+    } else {
+        // disallow any fntypes
+        builder = builder.blocklist_type(".*fntype.*");
+    }
 
     if cfg!(feature = "cuda") {
         builder = builder.clang_arg("-DENABLE_CUDA");


### PR DESCRIPTION
## What

Adds a default-off `tools` feature to `nvtx-sys` that extends the existing bindgen allowlist with the NVTX tools/injection ABI from `nvtxDetail/nvtxTypes.h`:

- The callback-subscription types: `NvtxExportTableCallbacks`, `NvtxExportTableVersionInfo`, `NvtxExportTableID`, `NvtxCallbackModule`, all six `NvtxCallbackId*` enums, `NvtxGetExportTableFunc_t`, `NvtxInitializeInjectionNvtxFunc_t`, `NvtxFunctionPointer`, and `NvtxFunctionTable`.
- The function-table slot signatures (`*_impl_fntype` / `*_fakeimpl_fntype`) and the dependency-free fake types they reference (`nvtx_CUdevice`, `nvtx_cl_*`, ...), so tools cast slots to header-defined signatures instead of hand-maintained ones.
- The injection result codes (`NVTX_SUCCESS`, `NVTX_FAIL`, `NVTX_ERR_*`).

## Why

Rust tools (injection libraries) currently have to run their own bindgen pipeline against the NVTX headers to get these types. Since `nvtx-sys` already generates bindings from the in-repo headers, exposing the tools ABI behind an opt-in feature lets tools depend on `nvtx-sys` directly.

This is the first of a series: follow-ups add subscriber support to the `nvtx` crate on top of this feature.

## Notes

- With `tools` disabled, the generated bindings are byte-identical to before (verified by diffing generated `bindings.rs`); with it enabled they are a strict superset.
- The wrapper already parses `nvtxTypes.h` (it is included even under `NVTX_NO_IMPL`), so this only changes the allowlist/blocklist: the `.*fntype.*` blocklist now applies only when `tools` is off.

## Verification

- `check.sh` profiles pass: fmt, check/clippy `-Dwarnings` and tests for `--all-features`, `--no-default-features` (± `alloc`), MSRV 1.77, and the `thumbv7em-none-eabi` no-default check; plus `--features tools` alone and `tools,cuda,cuda_runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
